### PR TITLE
Use latest devise

### DIFF
--- a/devise_google_authenticator.gemspec
+++ b/devise_google_authenticator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     # removed the following to try and get past this bundle update not finding compatible versions for gem issue
     # 'actionmailer' => '>= 3.0', 
     #'actionmailer' => '~> 3.2',# '>= 3.2.12',
-    'devise' => '~> 3.2',
+    'devise' => '~> 4.4.0',
     'rotp'   => '~> 1.6'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)


### PR DESCRIPTION
This will allow us to upgrade to ruby 2.5.0 and rails 5

PR sent to the upstream repo too: https://github.com/AsteriskLabs/devise_google_authenticator/pull/58/files